### PR TITLE
[00_python] fix error in notebook in slice stop argument explanation

### DIFF
--- a/00_python/notebook.ipynb
+++ b/00_python/notebook.ipynb
@@ -1051,7 +1051,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s[2:]"
+    "s[:2]"
    ]
   },
   {


### PR DESCRIPTION
As discussed during course, this should be `:2` to correspond to the text above and below about the `stop` argument.